### PR TITLE
Filter events by type in throughput calculation

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -84,7 +84,7 @@ def throughput_for_run(
         return pl.DataFrame()
 
     min_ts = events.select(pl.col("timestamp").min()).item()
-    
+
     throughput = (
         events.sort("timestamp")
         # [t0, t0+window), [t0+1s, t0+1s+window), ...]


### PR DESCRIPTION
The throughput_for_run function now filters events to include only those with event_type 'Publication' before calculating throughput. This ensures that only relevant events are considered in the throughput metric.