### PR TITLE
Make throughput event type configurable and include it in cache key

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -67,10 +67,12 @@ def throughput_for_run(
     tech: str,
     run: str,
     window_s: int,
+    event_type: str = "Publication",
     logs_root: str | Path = "logs",
 ) -> pl.DataFrame:
     cache_dir = get_cache_dir(scenario, logs_root)
-    cache_path = cache_dir / f"throughput_{tech}_{run}_{window_s}s.parquet"
+    event_label = event_type.lower()
+    cache_path = cache_dir / f"throughput_{tech}_{run}_{event_label}_{window_s}s.parquet"
     if cache_path.exists():
         return pl.read_parquet(cache_path)
     run_dir = get_run_dir(scenario, tech, run, logs_root)
@@ -78,8 +80,8 @@ def throughput_for_run(
     if events.is_empty():
         return pl.DataFrame()
 
-    # Anchor throughput to publications only (avoid double-counting and time-base mismatch)
-    events = events.filter(pl.col("event_type") == "Publication")
+    # Anchor throughput to selected event type (avoid double-counting and time-base mismatch)
+    events = events.filter(pl.col("event_type") == event_type)
     if events.is_empty():
         return pl.DataFrame()
 

--- a/app.py
+++ b/app.py
@@ -28,8 +28,9 @@ def load_throughput(
     tech: str,
     run: str,
     window_s: int,
+    event_type: str,
 ) -> pl.DataFrame:
-    return throughput_for_run(scenario, tech, run, window_s)
+    return throughput_for_run(scenario, tech, run, window_s, event_type)
 
 
 @st.cache_data(show_spinner=False)
@@ -89,6 +90,11 @@ def main() -> None:
         value=min(10, duration_s),
         step=1,
     )
+    throughput_event_type = st.sidebar.selectbox(
+        "Throughput event type",
+        ["Publication", "Reception"],
+        index=0,
+    )
     show_individual = st.sidebar.checkbox("Show individual runs", value=False)
 
     st.header("Performance Summary")
@@ -110,7 +116,9 @@ def main() -> None:
         for run in runs_by_tech.get(tech, []):
             if run not in selected_runs:
                 continue
-            throughput = load_throughput(scenario, tech, run, window_s)
+            throughput = load_throughput(
+                scenario, tech, run, window_s, throughput_event_type
+            )
             if not throughput.is_empty():
                 run_frames.append(
                     throughput.with_columns(
@@ -199,11 +207,12 @@ def main() -> None:
     for column, tech in zip(kpi_columns, selected_techs):
         throughput_value, latency_value = kpi_data.get(tech, (0, 0))
         column.metric(
-            label=f"{tech} Avg Throughput (MB/s)", value=f"{throughput_value:,.2f}"
+            label=f"{tech} Avg {throughput_event_type} Throughput (MB/s)",
+            value=f"{throughput_value:,.2f}",
         )
         column.metric(label=f"{tech} P99 Latency (ms)", value=f"{latency_value:,.2f}")
 
-    st.header("Throughput (MB/s)")
+    st.header(f"{throughput_event_type} Throughput (MB/s)")
     throughput_display = (
         pl.concat(throughput_frames, how="vertical")
         if throughput_frames
@@ -214,9 +223,9 @@ def main() -> None:
             frame
             for tech in selected_techs
             for frame in [
-                load_throughput(scenario, tech, run, window_s).with_columns(
-                    pl.lit(tech).alias("tech"), pl.lit(run).alias("run")
-                )
+                load_throughput(
+                    scenario, tech, run, window_s, throughput_event_type
+                ).with_columns(pl.lit(tech).alias("tech"), pl.lit(run).alias("run"))
                 for run in runs_by_tech.get(tech, [])
                 if run in selected_runs
             ]


### PR DESCRIPTION
### Motivation
- Allow computing throughput over either `Publication` or `Reception` events instead of hard-coding `Publication`.
- Prevent cache collisions and stale results when switching the event type by incorporating the selection into the cache key.
- Expose the choice in the Streamlit UI so users can toggle which event type is used for throughput plots and KPIs.

### Description
- Added an `event_type: str = "Publication"` parameter to `throughput_for_run` and changed the event filter to `events.filter(pl.col("event_type") == event_type)`.
- Updated the throughput cache path to include a lowercase `event_type` label via `throughput_{tech}_{run}_{event_label}_{window_s}s.parquet`.
- Propagated the new parameter through the app by adding `event_type` to `load_throughput`, wiring it into calls, and adding a sidebar `selectbox` with `"Publication"` and `"Reception"` options.
- Updated UI labels and the throughput header/metrics to reflect the selected `throughput_event_type` and ensure individual-run loading respects the selection.

### Testing
- Launched the Streamlit app with `streamlit run app.py` and loaded the main page, and a screenshot was captured successfully, indicating the UI control renders and the app starts.
- No unit tests were run on the modified code during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69566e84f79c83308ea02a37f0547fa2)