### PR TITLE
Implement NATS p2p publisher and consumer

### DIFF
--- a/technologies/nats_p2p/NatsConsumer.cpp
+++ b/technologies/nats_p2p/NatsConsumer.cpp
@@ -1,0 +1,266 @@
+#include "NatsConsumer.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "Payload.hpp"
+#include "Utils.hpp"
+
+namespace {
+std::string build_nats_url(const std::string &endpoint,
+                           const std::string &port) {
+	if (endpoint.rfind("nats://", 0) == 0 || endpoint.rfind("tls://", 0) == 0) {
+		return endpoint;
+	}
+	return "nats://" + endpoint + ":" + port;
+}
+
+void destroy_subscription(std::unique_ptr<natsSubscription> &subscription) {
+	if (!subscription)
+		return;
+	natsSubscription_Destroy(subscription.get());
+	subscription.release();
+}
+
+void destroy_connection(std::unique_ptr<natsConnection> &connection) {
+	if (!connection)
+		return;
+	natsConnection_Destroy(connection.get());
+	connection.release();
+}
+} // namespace
+
+NatsConsumer::NatsConsumer(std::shared_ptr<Logger> logger)
+    : IConsumer(logger) {
+	logger->log_info("[NATS Consumer] NatsConsumer created.");
+}
+
+NatsConsumer::~NatsConsumer() {
+	logger->log_debug("[NATS Consumer] Cleaning up NATS consumer...");
+	destroy_subscription(subscription_);
+	destroy_connection(connection_);
+	logger->log_debug("[NATS Consumer] Destructor finished.");
+}
+
+void NatsConsumer::initialize() {
+	const std::optional<std::string> vtopics = utils::get_env_var("TOPICS");
+	if (!vtopics || vtopics->empty()) {
+		throw std::runtime_error(
+		    "[NATS Consumer] Missing required environment variable TOPICS.");
+	}
+
+	const std::optional<std::string> vurl = utils::get_env_var("NATS_URL");
+	if (vurl && !vurl->empty()) {
+		nats_url_ = vurl.value();
+	} else {
+		const std::string endpoints = utils::get_env_var_or_default(
+		    "CONSUMER_ENDPOINT", "localhost");
+		std::string endpoint;
+		std::istringstream endpoints_stream(endpoints);
+		std::getline(endpoints_stream, endpoint, ',');
+		if (endpoint.empty()) {
+			throw std::runtime_error(
+			    "[NATS Consumer] CONSUMER_ENDPOINT is empty.");
+		}
+
+		const std::string port = utils::get_env_var_or_default(
+		    "NATS_PORT",
+		    utils::get_env_var_or_default("CONSUMER_PORT", "4222"));
+
+		nats_url_ = build_nats_url(endpoint, port);
+	}
+
+	std::unordered_set<std::string> unique_topics;
+	std::string topic;
+	std::istringstream topics_stream(vtopics.value());
+	while (std::getline(topics_stream, topic, ',')) {
+		if (topic.empty()) {
+			continue;
+		}
+		if (unique_topics.insert(topic).second) {
+			subscribe(topic);
+		}
+	}
+
+	if (unique_topics.empty()) {
+		throw std::runtime_error("[NATS Consumer] No valid topics provided.");
+	}
+
+	natsConnection *conn = nullptr;
+	natsStatus status = natsConnection_ConnectTo(&conn, nats_url_.c_str());
+	if (status != NATS_OK) {
+		throw std::runtime_error(
+		    "[NATS Consumer] Failed to connect: "
+		    + std::string(natsStatus_GetText(status)));
+	}
+	connection_.reset(conn);
+
+	natsSubscription *sub = nullptr;
+	status = natsConnection_SubscribeSync(&sub, conn, ">");
+	if (status != NATS_OK) {
+		throw std::runtime_error(
+		    "[NATS Consumer] Failed to subscribe: "
+		    + std::string(natsStatus_GetText(status)));
+	}
+	subscription_.reset(sub);
+
+	logger->log_info("[NATS Consumer] Consumer initialized.");
+	log_configuration();
+}
+
+void NatsConsumer::subscribe(const std::string &subject) {
+	logger->log_info("[NATS Consumer] Registering topic: " + subject);
+	subscribed_streams.inc();
+}
+
+bool NatsConsumer::deserialize(const void *raw_message, size_t len,
+                               Payload &out) {
+	const char *data = static_cast<const char *>(raw_message);
+	size_t offset = 0;
+
+	if (len < sizeof(uint16_t) + sizeof(uint8_t) + sizeof(size_t)) {
+		logger->log_error("[NATS Consumer] Message too short to deserialize.");
+		return false;
+	}
+
+	uint16_t id_len = 0;
+	std::memcpy(&id_len, data + offset, sizeof(id_len));
+	offset += sizeof(id_len);
+
+	if (len < offset + id_len + sizeof(uint8_t) + sizeof(size_t)) {
+		logger->log_error(
+		    "[NATS Consumer] Invalid message: id length out of bounds.");
+		return false;
+	}
+
+	std::string message_id(data + offset, id_len);
+	offset += id_len;
+
+	uint8_t kind_byte = 0;
+	std::memcpy(&kind_byte, data + offset, sizeof(kind_byte));
+	offset += sizeof(kind_byte);
+	PayloadKind kind_payload = static_cast<PayloadKind>(kind_byte);
+
+	size_t data_size = 0;
+	std::memcpy(&data_size, data + offset, sizeof(data_size));
+	offset += sizeof(data_size);
+
+	if (len != offset + data_size) {
+		logger->log_error(
+		    "[NATS Consumer] Mismatch in expected data size. Expected total "
+		    "size: "
+		    + std::to_string(offset + data_size)
+		    + ", actual size: " + std::to_string(len));
+		return false;
+	}
+
+	std::vector<uint8_t> payload_data(data + offset, data + offset + data_size);
+
+	out.message_id = std::move(message_id);
+	out.kind = kind_payload;
+	out.data_size = data_size;
+	out.data = std::move(payload_data);
+
+	return true;
+}
+
+void NatsConsumer::start_loop() {
+	const std::optional<std::string> vtopics = utils::get_env_var("TOPICS");
+	if (!vtopics || vtopics->empty()) {
+		logger->log_error("[NATS Consumer] No topics to subscribe.");
+		return;
+	}
+
+	std::unordered_set<std::string> allowed_topics;
+	std::string topic;
+	std::istringstream topics_stream(vtopics.value());
+	while (std::getline(topics_stream, topic, ',')) {
+		if (!topic.empty()) {
+			allowed_topics.insert(topic);
+		}
+	}
+
+	std::unordered_set<std::string> completed_topics;
+
+	while (true) {
+		natsMsg *msg = nullptr;
+		natsStatus status =
+		    natsSubscription_NextMsg(&msg, subscription_.get(), 1000);
+		if (status == NATS_TIMEOUT) {
+			continue;
+		}
+		if (status != NATS_OK) {
+			logger->log_error("[NATS Consumer] Receive failed: "
+			                  + std::string(natsStatus_GetText(status)));
+			continue;
+		}
+		if (!msg) {
+			continue;
+		}
+
+		const char *subject = natsMsg_GetSubject(msg);
+		const std::string subject_str = subject ? subject : "";
+
+		if (!allowed_topics.empty()
+		    && allowed_topics.find(subject_str) == allowed_topics.end()) {
+			natsMsg_Destroy(msg);
+			continue;
+		}
+
+		Payload payload;
+		const void *data_ptr = natsMsg_GetData(msg);
+		const size_t data_len = static_cast<size_t>(natsMsg_GetDataLength(msg));
+
+		if (!deserialize(data_ptr, data_len, payload)) {
+			logger->log_error("[NATS Consumer] Deserialization failed.");
+			natsMsg_Destroy(msg);
+			continue;
+		}
+
+		const size_t total_size = sizeof(uint16_t) + payload.message_id.size()
+		    + sizeof(uint8_t) + sizeof(size_t) + payload.data_size;
+
+		logger->log_info("[NATS Consumer] Received message ID: "
+		                 + payload.message_id + ", Size: "
+		                 + std::to_string(payload.data_size) + " bytes");
+		logger->log_study("Reception," + payload.message_id + ","
+		                  + std::to_string(payload.data_size) + ","
+		                  + subject_str + "," + std::to_string(total_size));
+
+		if (payload.message_id.find(TERMINATION_SIGNAL) != std::string::npos) {
+			if (completed_topics.insert(subject_str).second) {
+				subscribed_streams.dec();
+			}
+			logger->log_info(
+			    "[NATS Consumer] Termination signal received for topic: "
+			    + subject_str);
+			if (subscribed_streams.get() == 0) {
+				logger->log_info(
+				    "[NATS Consumer] All streams terminated. Exiting.");
+				natsMsg_Destroy(msg);
+				break;
+			}
+			logger->log_info(
+			    "[NATS Consumer] Remaining subscribed streams: "
+			    + std::to_string(subscribed_streams.get()));
+		}
+
+		natsMsg_Destroy(msg);
+	}
+}
+
+void NatsConsumer::log_configuration() {
+	logger->log_config("[NATS Consumer] [CONFIG_BEGIN]");
+	logger->log_config("[CONFIG] NATS_URL=" + nats_url_);
+	logger->log_config("[CONFIG] TOPICS="
+	                   + utils::get_env_var_or_default("TOPICS", ""));
+	logger->log_config("[NATS Consumer] [CONFIG_END]");
+}

--- a/technologies/nats_p2p/NatsPublisher.cpp
+++ b/technologies/nats_p2p/NatsPublisher.cpp
@@ -1,0 +1,126 @@
+#include "NatsPublisher.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "Payload.hpp"
+#include "Utils.hpp"
+
+namespace {
+std::string build_nats_url(const std::string &endpoint,
+                           const std::string &port) {
+	if (endpoint.rfind("nats://", 0) == 0 || endpoint.rfind("tls://", 0) == 0) {
+		return endpoint;
+	}
+	return "nats://" + endpoint + ":" + port;
+}
+
+void destroy_connection(std::unique_ptr<natsConnection> &connection) {
+	if (!connection)
+		return;
+	natsConnection_Destroy(connection.get());
+	connection.release();
+}
+} // namespace
+
+NatsPublisher::NatsPublisher(std::shared_ptr<Logger> logger)
+    : IPublisher(logger) {
+	logger->log_info("[NATS Publisher] NatsPublisher created.");
+}
+
+NatsPublisher::~NatsPublisher() {
+	logger->log_debug("[NATS Publisher] Cleaning up NATS publisher...");
+	destroy_connection(connection_);
+	logger->log_debug("[NATS Publisher] Destructor finished.");
+}
+
+void NatsPublisher::initialize() {
+	const std::optional<std::string> vurl = utils::get_env_var("NATS_URL");
+	if (vurl && !vurl->empty()) {
+		nats_url_ = vurl.value();
+	} else {
+		std::string endpoint = utils::get_env_var_or_default(
+		    "PUBLISHER_ENDPOINT", "127.0.0.1");
+		if (endpoint == "0.0.0.0") {
+			endpoint = "127.0.0.1";
+		}
+		const std::string port = utils::get_env_var_or_default(
+		    "NATS_PORT",
+		    utils::get_env_var_or_default("PUBLISHER_PORT", "4222"));
+		nats_url_ = build_nats_url(endpoint, port);
+	}
+
+	natsConnection *conn = nullptr;
+	natsStatus status = natsConnection_ConnectTo(&conn, nats_url_.c_str());
+	if (status != NATS_OK) {
+		throw std::runtime_error(
+		    "[NATS Publisher] Failed to connect: "
+		    + std::string(natsStatus_GetText(status)));
+	}
+	connection_.reset(conn);
+
+	logger->log_info("[NATS Publisher] Publisher initialized.");
+	log_configuration();
+}
+
+bool NatsPublisher::serialize(const Payload &message, void *out) {
+	char *ptr = static_cast<char *>(out);
+
+	const uint16_t id_len = static_cast<uint16_t>(message.message_id.size());
+	std::memcpy(ptr, &id_len, sizeof(id_len));
+	ptr += sizeof(id_len);
+
+	std::memcpy(ptr, message.message_id.data(), id_len);
+	ptr += id_len;
+
+	const uint8_t kind = static_cast<uint8_t>(message.kind);
+	std::memcpy(ptr, &kind, sizeof(kind));
+	ptr += sizeof(kind);
+
+	const size_t size = static_cast<size_t>(message.data_size);
+	std::memcpy(ptr, &size, sizeof(size));
+	ptr += sizeof(size);
+
+	std::memcpy(ptr, message.data.data(), size);
+
+	return true;
+}
+
+void NatsPublisher::send_message(const Payload &message, std::string &subject) {
+	const size_t serialized_size = sizeof(uint16_t)
+	    + message.message_id.size() + sizeof(uint8_t) + sizeof(size_t)
+	    + message.data_size;
+	std::string serialized(serialized_size, '\0');
+	if (!serialize(message, serialized.data())) {
+		logger->log_error(
+		    "[NATS Publisher] Serialization failed for message ID: "
+		    + message.message_id);
+		return;
+	}
+
+	natsStatus status = natsConnection_Publish(
+	    connection_.get(), subject.c_str(), serialized.data(),
+	    static_cast<int>(serialized.size()));
+
+	if (status != NATS_OK) {
+		logger->log_error("[NATS Publisher] Publish failed: "
+		                  + std::string(natsStatus_GetText(status)));
+		return;
+	}
+
+	logger->log_study("Publication," + message.message_id + ","
+	                  + std::to_string(message.data_size) + "," + subject + ","
+	                  + std::to_string(serialized_size));
+}
+
+void NatsPublisher::log_configuration() {
+	logger->log_config("[NATS Publisher] [CONFIG_BEGIN]");
+	logger->log_config("[CONFIG] NATS_URL=" + nats_url_);
+	logger->log_config("[CONFIG] TOPICS="
+	                   + utils::get_env_var_or_default("TOPICS", ""));
+	logger->log_config("[NATS Publisher] [CONFIG_END]");
+}


### PR DESCRIPTION
### Motivation
- Add a p2p NATS implementation to enable publisher/consumer benchmarks using the existing interfaces `IPublisher` and `IConsumer`.
- Support a publisher co-located with a NATS server and enable fan-out (single publisher -> multiple consumers, multiple topics).
- Match code structure, error handling and lifecycle management conventions used by other technologies (e.g. `ArrowFlight` and `ZeroMQ`).
- Provide consistent configuration and logging via environment variables and the shared `Logger`.

### Description
- Implemented `technologies/nats_p2p/NatsConsumer.cpp` which: connects via `natsConnection_ConnectTo`, creates a synchronous subscription (`natsConnection_SubscribeSync`), filters/handles topics from `TOPICS`, deserializes messages (format: `uint16_t id_len`, `message_id`, `uint8_t kind`, `size_t data_size`, `data`), tracks termination via `TERMINATION_SIGNAL`, and manages lifecycle via RAII helpers.
- Implemented `technologies/nats_p2p/NatsPublisher.cpp` which: resolves `NATS_URL`/endpoint fallbacks, connects to NATS, serializes `Payload` in the same binary format, publishes with `natsConnection_Publish`, and logs publications via `logger->log_study`.
- Added configuration handling and logging (`log_configuration`) using environment variables `NATS_URL`, `NATS_PORT`, `PUBLISHER_ENDPOINT`, `CONSUMER_ENDPOINT`, `PUBLISHER_PORT`, and `CONSUMER_PORT` to match platform orchestration.
- Introduced safe cleanup helpers for `natsConnection` and `natsSubscription` and used `std::unique_ptr` wrappers to manage resource lifetimes and error reporting similar to other technology modules.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd89df2308330b5943634e614d9db)