### PR TITLE
Update event timestamp format in metrics.py

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -7,7 +7,7 @@ import polars as pl
 
 from analysis.data_loader import get_cache_dir, get_run_dir
 
-EVENT_TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S%.fZ"
+EVENT_TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S%.f"
 RESOURCE_TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S%.f"
 
 


### PR DESCRIPTION
Changed EVENT_TIMESTAMP_FMT to use a space instead of 'T' and removed the trailing 'Z' to match the expected event timestamp format.