### PR TITLE
Update throughput window size slider range

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,9 +83,9 @@ def main() -> None:
 
     window_s = st.sidebar.slider(
         "Throughput window size (seconds)",
-        min_value=10,
-        max_value=max(10, duration_s),
-        value=min(10, duration_s),
+        min_value=1,
+        max_value=10,
+        value=10,
         step=1,
     )
     throughput_event_type = st.sidebar.selectbox(


### PR DESCRIPTION
Changed the throughput window size slider to have a fixed range of 1 to 10 seconds, with a default value of 10. This simplifies the UI and removes dependency on the duration_s variable.