### PR TITLE
Add delay before exit in PublisherApp main

### DIFF
--- a/core/applications/PublisherApp.cpp
+++ b/core/applications/PublisherApp.cpp
@@ -215,7 +215,8 @@ void PublisherApp::run() {
 
 	logger->log_info("[PublisherApp] Terminating");
 	terminate_all_topics();
-	// Give some time for messages to be sent before exiting
+	// Give some time for messages to be received before exiting
+	sleep_time = 8000; // milliseconds
 	std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
 	logger->log_info("[PublisherApp] Terminated");
 }


### PR DESCRIPTION
#15 

This pull request makes a minor but important correction to the shutdown procedure in `PublisherApp::run()`. The comment is updated to clarify that the sleep period at termination is to allow messages to be received, not sent, and the sleep duration is explicitly set to 8000 milliseconds.

- Clarified the shutdown comment to state that the sleep period is for messages to be received, and set `sleep_time` to 8000 milliseconds in `PublisherApp::run()` (`core/applications/PublisherApp.cpp`).#15

Inserted a 8-second sleep at the end of main to ensure all messages are sent before the application exits, particularly when producer and broker run on the same machine.