### PR TITLE
Increase max message size for Kafka and NATS

### DIFF
--- a/technologies/kafka_p2p/KafkaCppConsumer.cpp
+++ b/technologies/kafka_p2p/KafkaCppConsumer.cpp
@@ -156,8 +156,9 @@ void KafkaCppConsumer::initialize() {
 	conf_->set("fetch.min.bytes", "1", err_msg);
 	conf_->set("fetch.wait.max.ms", "5", err_msg);
 
-	conf_->set("max.partition.fetch.bytes", "8388608", err_msg);
-	conf_->set("fetch.message.max.bytes", "8388608", err_msg);
+	// Support larger messages if needed (up to 16MB here).
+	conf_->set("max.partition.fetch.bytes", "16777216", err_msg);
+	conf_->set("fetch.message.max.bytes", "16777216", err_msg);
 	conf_->set("queued.max.messages.kbytes", "4194304", err_msg);
 
 	consumer_.reset(RdKafka::KafkaConsumer::create(conf_.get(), err_msg));

--- a/technologies/kafka_p2p/KafkaCppPublisher.cpp
+++ b/technologies/kafka_p2p/KafkaCppPublisher.cpp
@@ -86,6 +86,8 @@ void KafkaCppPublisher::initialize() {
 	conf_->set("compression.type", "none", errstr);
 	conf_->set("queue.buffering.max.kbytes", "4194304", errstr);
 	conf_->set("queue.buffering.max.messages", "1000000", errstr);
+	// Force to send large messages if needed
+	conf_->set("message.max.bytes", "16777216", errstr);
 
 	producer_.reset(RdKafka::Producer::create(conf_.get(), errstr));
 

--- a/technologies/kafka_p2p/server.properties
+++ b/technologies/kafka_p2p/server.properties
@@ -25,6 +25,9 @@ node.id=1
 controller.quorum.bootstrap.servers=localhost:9093
 controller.quorum.voters=1@localhost:9093
 
+# maximm message size the broker will receive
+message.max.bytes=16777216
+
 ############################# Socket Server Settings #############################
 
 # The address the socket server listens on.

--- a/technologies/nats_p2p/nats.config
+++ b/technologies/nats_p2p/nats.config
@@ -1,5 +1,5 @@
 port: 4222
 
 # Limits
-max_payload: 8MB
+max_payload: 16MB
 max_pending: 1024MB


### PR DESCRIPTION
This pull request increases the maximum allowed message size across both Kafka and NATS configurations to support larger payloads (up to 16MB). The changes ensure that both producers, consumers, and brokers in Kafka, as well as the NATS server, are configured consistently to handle these larger messages.

**Kafka configuration updates:**

* Increased `max.partition.fetch.bytes` and `fetch.message.max.bytes` to 16MB in `KafkaCppConsumer.cpp` to allow consumers to receive larger messages.
* Set `message.max.bytes` to 16MB in `KafkaCppPublisher.cpp` so producers can send larger messages.
* Added `message.max.bytes=16777216` to `server.properties` to configure the broker to accept messages up to 16MB.

**NATS configuration update:**

* Increased `max_payload` from 8MB to 16MB in `nats.config` to allow larger messages through the NATS server.Raised the maximum message size to 16MB in Kafka consumer, publisher, and broker configurations, as well as in the NATS server config. This change allows the system to handle larger messages across both messaging technologies.