### PR TITLE
Refactor publisher to pump event loop synchronously

### DIFF
--- a/technologies/rabbitmq_p2p/RabbitMQPublisher.hpp
+++ b/technologies/rabbitmq_p2p/RabbitMQPublisher.hpp
@@ -3,10 +3,8 @@
 #include <amqpcpp.h>
 #include <amqpcpp/libevent.h>
 #include <atomic>
-#include <condition_variable>
 #include <cstddef>
 #include <memory>
-#include <mutex>
 #include <string>
 
 #include "IPublisher.hpp"
@@ -38,8 +36,6 @@ class RabbitMQPublisher : public IPublisher {
 	std::unique_ptr<AMQP::TcpConnection> connection_;
 	std::unique_ptr<AMQP::TcpChannel> channel_;
 	size_t max_out_queue_bytes_;
-	std::mutex ready_mu_;
-	std::condition_variable ready_cv_;
 	std::atomic<bool> ready_{false};
 	std::atomic<bool> terminated_{false};
 };


### PR DESCRIPTION
Replace event-based scheduled publishes and background IO thread with a synchronous publish path that pumps the libevent loop. Removed the internal EventItem allocation and event_base_once usage; publish now calls channel_->publish directly and uses a new pump_event_loop_(int) helper to drive the event loop. Adjusted throttling/polling delays and changed default RABBITMQ_MAX_OUT_BUFFER_BYTES from 1GB to 32MB. Simplified startup/shutdown by removing start_event_loop_ and the io_thread_ member; wait_ready_ now polls + pumps the loop instead of waiting on a condition variable. Also moved termination handling to the immediate publish path and cleaned up related header includes and declarations.