### PR TITLE
Fixed Issue #45

### DIFF
--- a/core/orchestrator/benchmark_manager.py
+++ b/core/orchestrator/benchmark_manager.py
@@ -173,7 +173,10 @@ class BenchmarkManager:
             self.cm.wake_all()
             logger.info("Containers unpaused. Collecting metrics...")
             # self.cm.wait_for_all()
-            self.cm.wait_for_consumers()
+            if tech_name == 'zeromq_p2p':
+                self.cm.wait_for_publishers()
+            else:
+                self.cm.wait_for_consumers()
             metrics.stop()
             events_logger = ContainerEventsLogger(
                 tech_name, scenario_name, self.scenario_name, date_time

--- a/core/orchestrator/container_manager.py
+++ b/core/orchestrator/container_manager.py
@@ -386,6 +386,12 @@ class ContainerManager:
         for container in self.consumer_containers:
             container.wait()
 
+    def wait_for_publishers(self) -> None:
+        """Waits for all publisher containers to finish."""
+        logger.debug("Waiting for all publisher containers to finish...")
+        for container in self.publisher_containers:
+            container.wait()
+
     @validate_container
     def wait_for_container(self, container_id: str) -> None:
         logger.debug(f"Waiting for container {container_id} to finish...")


### PR DESCRIPTION
#45 

Based on the current implementation, it is difficult to prevent message loss in ZeroMQ. As a temporary workaround, a hotfix has been introduced in the orchestrator. When the selected technology is zeromq_p2p, the orchestrator treats the publisher’s termination as the terminal signal and listens for its exit accordingly.